### PR TITLE
DNS config for the VPN UI

### DIFF
--- a/static/skywire-manager-src/src/app/app.module.ts
+++ b/static/skywire-manager-src/src/app/app.module.ts
@@ -96,6 +96,7 @@ import { VpnErrorComponent } from './components/vpn/pages/vpn-error/vpn-error.co
 import { VpnServerNameComponent } from './components/vpn/layout/vpn-server-name/vpn-server-name.component';
 import { EnterVpnServerPasswordComponent } from './components/vpn/pages/vpn-server-list/enter-vpn-server-password/enter-vpn-server-password.component';
 import { UpdateAllComponent } from './components/layout/update-all/update-all.component';
+import { VpnDnsConfigComponent } from './components/vpn/layout/vpn-dns-config/vpn-dns-config.component';
 
 const globalRippleConfig: RippleGlobalOptions = {
   disabled: true,
@@ -168,6 +169,7 @@ const globalRippleConfig: RippleGlobalOptions = {
     VpnServerNameComponent,
     EnterVpnServerPasswordComponent,
     UpdateAllComponent,
+    VpnDnsConfigComponent,
   ],
   imports: [
     BrowserModule,

--- a/static/skywire-manager-src/src/app/components/vpn/layout/vpn-dns-config/vpn-dns-config.component.html
+++ b/static/skywire-manager-src/src/app/components/vpn/layout/vpn-dns-config/vpn-dns-config.component.html
@@ -1,0 +1,10 @@
+<app-dialog [headline]="'vpn.dns-config.title' | translate">
+  <form [formGroup]="form">
+    <mat-form-field>
+      <input #firstInput [placeholder]="'vpn.dns-config.ip' | translate" formControlName="ip" maxlength="15" matInput>
+    </mat-form-field>
+  </form>
+  <app-button #button class="float-right" color="primary" (action)="save()" [disabled]="!form.valid">
+    {{ 'vpn.dns-config.save-config-button' | translate }}
+  </app-button>
+</app-dialog>

--- a/static/skywire-manager-src/src/app/components/vpn/layout/vpn-dns-config/vpn-dns-config.component.ts
+++ b/static/skywire-manager-src/src/app/components/vpn/layout/vpn-dns-config/vpn-dns-config.component.ts
@@ -1,0 +1,135 @@
+import { Component, Inject, ViewChild, ElementRef, OnInit, OnDestroy } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogConfig, MatDialog } from '@angular/material/dialog';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { Subscription } from 'rxjs';
+
+import { SnackbarService } from '../../../../services/snackbar.service';
+import { AppConfig } from 'src/app/app.config';
+import { ButtonComponent } from 'src/app/components/layout/button/button.component';
+import { OperationError } from 'src/app/utils/operation-error';
+import { processServiceError } from 'src/app/utils/errors';
+import { AppsService } from 'src/app/services/apps.service';
+import { VpnClientService } from 'src/app/services/vpn-client.service';
+
+/**
+ * Params for VpnDnsConfigComponent.
+ */
+export interface VpnDnsConfigParams {
+  /**
+   * PK of the node.
+   */
+  nodePk: string;
+  /**
+   * Current value of the dns property in the app.
+   */
+   ip: string;
+}
+
+/**
+ * Modal window for changing the dns configuration of the vpn client app. It changes the values
+ * and shows a confirmation msg by itself.
+ */
+@Component({
+  selector: 'app-vpn-dns-config',
+  templateUrl: './vpn-dns-config.component.html',
+  styleUrls: ['./vpn-dns-config.component.scss']
+})
+export class VpnDnsConfigComponent implements OnInit, OnDestroy {
+  @ViewChild('button') button: ButtonComponent;
+  @ViewChild('firstInput') firstInput: ElementRef;
+
+  form: FormGroup;
+
+  private operationSubscription: Subscription;
+
+  /**
+   * Opens the modal window. Please use this function instead of opening the window "by hand".
+   */
+  public static openDialog(dialog: MatDialog, node: VpnDnsConfigParams): MatDialogRef<VpnDnsConfigComponent, any> {
+    const config = new MatDialogConfig();
+    config.data = node;
+    config.autoFocus = false;
+    config.width = AppConfig.smallModalWidth;
+
+    return dialog.open(VpnDnsConfigComponent, config);
+  }
+
+  constructor(
+    private dialogRef: MatDialogRef<VpnDnsConfigComponent>,
+    @Inject(MAT_DIALOG_DATA) private data: VpnDnsConfigParams,
+    private formBuilder: FormBuilder,
+    private snackbarService: SnackbarService,
+    private appsService: AppsService,
+    private vpnClientService: VpnClientService,
+  ) { }
+
+  ngOnInit() {
+    this.form = this.formBuilder.group({
+      ip: [this.data.ip, Validators.compose([
+        Validators.maxLength(15),
+        this.validateIp.bind(this)
+      ])],
+    });
+
+    setTimeout(() => (this.firstInput.nativeElement as HTMLElement).focus());
+  }
+
+  ngOnDestroy() {
+    if (this.operationSubscription) {
+      this.operationSubscription.unsubscribe();
+    }
+  }
+
+  private validateIp() {
+    if (this.form) {
+      const value = this.form.get('ip').value as string;
+      if (!value) {
+        return;
+      }
+
+      const parts = value.split('.');
+      if (parts.length !== 4) {
+        return { invalid: true };
+      }
+
+      for (const part of parts) {
+        const number = Number.parseInt(part, 10);
+        if (isNaN(number) || (number + '') !== part || number < 0 || number > 255) {
+          return { invalid: true };
+        }
+      }
+    }
+
+    return null;
+  }
+
+  save() {
+    if (!this.form.valid || this.operationSubscription) {
+      return;
+    }
+
+    this.button.showLoading();
+
+    this.operationSubscription = this.appsService.changeAppSettings(
+      this.data.nodePk,
+      this.vpnClientService.vpnClientAppName,
+      { dns: this.form.get('ip').value },
+    ).subscribe({
+      next: this.onSuccess.bind(this),
+      error: this.onError.bind(this)
+    });
+  }
+
+  private onSuccess(response: any) {
+    this.dialogRef.close(true);
+    this.snackbarService.showDone('vpn.dns-config.done');
+  }
+
+  private onError(err: OperationError) {
+    this.button.showError();
+    this.operationSubscription = null;
+    err = processServiceError(err);
+
+    this.snackbarService.showError(err);
+  }
+}

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-settings/vpn-settings.component.html
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-settings/vpn-settings.component.html
@@ -95,6 +95,18 @@
             {{ backendData.vpnClientAppData.minHops }}
           </td>
         </tr>
+        <!-- Dns. -->
+        <tr class="selectable" (click)="changeDns()">
+          <td class="data-column">
+            <div>
+              {{ 'vpn.settings-page.dns' | translate }}
+              <mat-icon [inline]="true" class="help-icon" [matTooltip]="'vpn.settings-page.dns-info' | translate">help</mat-icon>
+            </div>
+          </td>
+          <td class="data-column">
+            {{ backendData.vpnClientAppData.dns ? backendData.vpnClientAppData.dns : ('vpn.settings-page.setting-none' | translate) }}
+          </td>
+        </tr>
       </table>
     </div></div>
   </div></div>

--- a/static/skywire-manager-src/src/app/components/vpn/pages/vpn-settings/vpn-settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/vpn/pages/vpn-settings/vpn-settings.component.ts
@@ -13,6 +13,7 @@ import GeneralUtils from 'src/app/utils/generalUtils';
 import { SelectableOption, SelectOptionComponent } from 'src/app/components/layout/select-option/select-option.component';
 import { TopBarComponent } from 'src/app/components/layout/top-bar/top-bar.component';
 import { RouterConfigComponent, RouterConfigParams } from 'src/app/components/pages/node/node-info/node-info-content/router-config/router-config.component';
+import { VpnDnsConfigComponent, VpnDnsConfigParams } from '../../layout/vpn-dns-config/vpn-dns-config.component';
 
 /**
  * Options that VpnSettingsComponent might be changing asynchronously.
@@ -238,5 +239,13 @@ export class VpnSettingsComponent implements OnDestroy {
   changeHops() {
     const params: RouterConfigParams = {nodePk: this.currentLocalPk, minHops: this.backendData.vpnClientAppData.minHops};
     RouterConfigComponent.openDialog(this.dialog, params).afterClosed().subscribe();
+  }
+
+  /**
+   * Opens the modal window for changing the dns configuration.
+   */
+  changeDns() {
+    const params: VpnDnsConfigParams = {nodePk: this.currentLocalPk, ip: this.backendData.vpnClientAppData.dns};
+    VpnDnsConfigComponent.openDialog(this.dialog, params).afterClosed().subscribe();
   }
 }

--- a/static/skywire-manager-src/src/app/services/vpn-client.service.ts
+++ b/static/skywire-manager-src/src/app/services/vpn-client.service.ts
@@ -85,6 +85,7 @@ export class VpnClientAppData {
     * Time the VPN has been connected, as returned by the backend. Undefined if the vpn is not connected.
     */
    connectionDuration: number;
+   dns: string;
 }
 
 /**
@@ -683,7 +684,7 @@ export class VpnClientService {
       // Get the min hops value.
       vpnClientData.minHops = nodeInfo.min_hops ? nodeInfo.min_hops : 0;
 
-      // Get the data transmission data, is the app is running.
+      // Get the data transmission data, if the app is running.
       if (vpnClientData && vpnClientData.running) {
         const o = new RequestOptions();
         o.vpnKeyForAuth = this.nodeKey;
@@ -785,6 +786,10 @@ export class VpnClientService {
 
         if (appData.args[i].toLowerCase().includes('-killswitch')) {
           vpnClientData.killswitch = (appData.args[i] as string).toLowerCase().includes('true');
+        }
+
+        if (appData.args[i].toLowerCase().includes('-dns')) {
+          vpnClientData.dns = appData.args[i + 1];
         }
       }
     }

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -888,6 +888,9 @@
       "data-units-info": "Allows to select the units that will be used to display the data transmission statistics.",
       "minimum-hops": "Minimum hops",
       "minimum-hops-info": "Allows to set the minimum number of hops the connections must pass through other Skywire visors before reaching the final destination.",
+      "dns": "Custom DNS server",
+      "dns-info": "Allows to use a custom DNS server, which could improve privacy and prevent sites from being blocked by the default DNS server of your ISP.",
+      "setting-none": "None",
       "setting-on": "On",
       "setting-off": "Off",
       "working-warning": "The system is busy. Please wait for the previous operation to finish.",
@@ -899,6 +902,13 @@
         "only-bytes": "Bytes for all stats",
         "bits-speed-and-bytes-volume": "Bits for speed and bytes for volume (default)"
       }
+    },
+
+    "dns-config": {
+      "title": "Custom DNS server",
+      "ip": "Custom DNS server IP address",
+      "save-config-button": "Save configuration",
+      "done": "Changes saved."
     }
   }
 }

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -892,6 +892,9 @@
       "data-units-info": "Permite seleccionar las unidades que se utilizarán para mostrar las estadísticas de transmisión de datos.",
       "minimum-hops": "Saltos mínimos",
       "minimum-hops-info": "Permite configurar la cantidad mínima de saltos que la conexión deberá realizar a través de otros visores de Skywire antes de alcanzar el destino final.",
+      "dns": "Servidor DNS personalizado",
+      "dns-info": "Permite usar un servidor DNS personalizado, lo que podría mejorar la privacidad y prevenir que algunos sitios sean bloqueados por el servidor DNS por defecto de su proveedor.",
+      "setting-none": "Ninguno",
       "setting-on": "Encendido",
       "setting-off": "Apagado",
       "working-warning": "El sistema está ocupado. Por favor, espere a que finalice la operación anterior.",
@@ -903,6 +906,13 @@
         "only-bytes": "Bytes para todas las estadísticas",
         "bits-speed-and-bytes-volume": "Bits para velocidad y bytes para volumen (predeterminado)"
       }
+    },
+
+    "dns-config": {
+      "title": "Servidor DNS personalizado",
+      "ip": "Dirección IP del servidor DNS personalizado",
+      "save-config-button": "Guardar configuración",
+      "done": "Cambios guardados."
     }
   }
 }

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -892,6 +892,9 @@
       "data-units-info": "Allows to select the units that will be used to display the data transmission statistics.",
       "minimum-hops": "Minimum hops",
       "minimum-hops-info": "Allows to set the minimum number of hops the connections must pass through other Skywire visors before reaching the final destination.",
+      "dns": "Custom DNS server",
+      "dns-info": "Allows to use a custom DNS server, which could improve privacy and prevent sites from being blocked by the default DNS server of your ISP.",
+      "setting-none": "None",
       "setting-on": "On",
       "setting-off": "Off",
       "working-warning": "The system is busy. Please wait for the previous operation to finish.",
@@ -903,6 +906,13 @@
         "only-bytes": "Bytes for all stats",
         "bits-speed-and-bytes-volume": "Bits for speed and bytes for volume (default)"
       }
+    },
+
+    "dns-config": {
+      "title": "Custom DNS server",
+      "ip": "Custom DNS server IP address",
+      "save-config-button": "Save configuration",
+      "done": "Changes saved."
     }
   }
 }


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- An option for using a custom DNS server was added to the settings page of the VPN UI.
![dns](https://user-images.githubusercontent.com/34079003/177620955-ee213210-c96c-4cd3-a957-fde50d72c7c8.png)

How to test this PR:
Use the new option