### PR TITLE
DNS config for the VPN in the manager

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.html
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.html
@@ -227,35 +227,47 @@
       </div>
     </mat-tab>
     <!-- Settings. -->
-    <mat-tab [label]="'apps.vpn-socks-client-settings.settings-tab' | translate">
-      <!-- Killswitch option. -->
-      <div class="main-theme settings-option">
-        <mat-checkbox
+    <mat-tab [label]="'apps.vpn-socks-client-settings.settings-tab' | translate" *ngIf="configuringVpn">
+      <form [formGroup]="settingsForm">
+        <!-- Killswitch option. -->
+        <div class="main-theme settings-option">
+          <mat-checkbox color="primary" formControlName="killswitch">
+            {{ 'apps.vpn-socks-client-settings.killswitch-check' | translate }}
+            <mat-icon [inline]="true" class="help-icon" [matTooltip]="'apps.vpn-socks-client-settings.killswitch-info' | translate">help</mat-icon>
+          </mat-checkbox>
+        </div>
+
+        <mat-form-field>
+          <input
+            formControlName="dns"
+            maxlength="15"
+            [placeholder]="'apps.vpn-socks-client-settings.dns' | translate"
+            matInput
+          >
+          <mat-error>
+            <ng-container *ngIf="!settingsForm.get('dns').valid">
+              {{ 'apps.vpn-socks-client-settings.dns-error' | translate }}
+            </ng-container>
+          </mat-error>
+        </mat-form-field>
+
+        <!-- Settings changed alert. -->
+        <div class="settings-changed-warning" *ngIf="settingsChanged">
+          <mat-icon [inline]="true">warning</mat-icon>
+          {{ 'apps.vpn-socks-client-settings.settings-changed-alert' | translate }}
+        </div>
+
+        <!-- Save button. -->
+        <app-button
+          #settingsButton
           color="primary"
-          [checked]="killswitch"
-          (change)="setKillswitch($event)"
+          class="float-right"
+          [disabled]="!settingsForm.valid || !settingsChanged || working"
+          (action)="saveSettings()"
         >
-          {{ 'apps.vpn-socks-client-settings.killswitch-check' | translate }}
-          <mat-icon [inline]="true" class="help-icon" [matTooltip]="'apps.vpn-socks-client-settings.killswitch-info' | translate">help</mat-icon>
-        </mat-checkbox>
-      </div>
-
-      <!-- Settings changed alert. -->
-      <div class="settings-changed-warning" *ngIf="killswitch !== initialKillswitchSetting">
-        <mat-icon [inline]="true">warning</mat-icon>
-        {{ 'apps.vpn-socks-client-settings.settings-changed-alert' | translate }}
-      </div>
-
-      <!-- Save button. -->
-      <app-button
-        #settingsButton
-        color="primary"
-        class="float-right"
-        [disabled]="killswitch === initialKillswitchSetting || working"
-        (action)="saveSettings()"
-      >
-        {{ 'apps.vpn-socks-client-settings.save-settings' | translate }}
-      </app-button>
+          {{ 'apps.vpn-socks-client-settings.save-settings' | translate }}
+        </app-button>
+      </form>
     </mat-tab>
   </mat-tab-group>
 </app-dialog>

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.scss
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.scss
@@ -122,13 +122,11 @@ form {
 }
 
 .settings-option {
-  margin: 15px 12px 10px 12px;
+  margin-top: 20px;
 }
 
 .settings-changed-warning {
   font-size: 0.7rem;
   opacity: 0.7;
   position: relative;
-  top: -5px;
-  padding: 0px 12px;
 }

--- a/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/apps/node-apps/skysocks-client-settings/skysocks-client-settings.component.ts
@@ -72,6 +72,7 @@ export class SkysocksClientSettingsComponent implements OnInit, OnDestroy {
   @ViewChild('settingsButton') settingsButton: ButtonComponent;
   @ViewChild('firstInput') firstInput: ElementRef;
   form: FormGroup;
+  settingsForm: FormGroup;
   // Entries to show on the history.
   history: HistoryEntry[];
 
@@ -103,10 +104,10 @@ export class SkysocksClientSettingsComponent implements OnInit, OnDestroy {
   // True if configuring Vpn-Client, false if configuring Skysocks-Client.
   configuringVpn = false;
 
-  // Indicates if the killswitch option is selected in the UI or not.
-  killswitch = false;
-  // Indicates if the killswitch is active in the backend or not.
+  // Indicates the value of the killswitch option in the backend the last time it was checked or changed.
   initialKillswitchSetting = false;
+  // Indicates the value of the dns option in the backend the last time it was checked or changed.
+  initialDnsSetting = '';
 
   // If the operation in currently being made.
   working = false;
@@ -173,11 +174,22 @@ export class SkysocksClientSettingsComponent implements OnInit, OnDestroy {
           currentVal = this.data.args[i + 1];
         }
         if ((this.data.args[i] as string).toLowerCase().includes('-killswitch')) {
-          this.killswitch = (this.data.args[i] as string).toLowerCase().includes('true');
-          this.initialKillswitchSetting = this.killswitch;
+          this.initialKillswitchSetting = (this.data.args[i] as string).toLowerCase().includes('true');
+        }
+
+        if ((this.data.args[i] as string).toLowerCase().includes('-dns')) {
+          this.initialDnsSetting = (this.data.args[i + 1] as string);
         }
       }
     }
+
+    this.settingsForm = this.formBuilder.group({
+      killswitch: [this.initialKillswitchSetting, Validators.required],
+      dns: [this.initialDnsSetting, Validators.compose([
+        Validators.maxLength(15),
+        this.validateIp.bind(this)
+      ])]
+    });
 
     this.form = this.formBuilder.group({
       pk: [currentVal, Validators.compose([
@@ -199,11 +211,22 @@ export class SkysocksClientSettingsComponent implements OnInit, OnDestroy {
     }
   }
 
-  // Used by the checkbox for the killswitch setting.
-  setKillswitch(event) {
-    if (!this.working) {
-      this.killswitch = event.checked ? true : false;
+  // Validates an IPv4 address.
+  private validateIp() {
+    if (this.settingsForm) {
+      const value = this.settingsForm.get('dns').value as string;
+      const validOrEmpty = GeneralUtils.checkIfIpValidOrEmpty(value);
+
+      return validOrEmpty ? null : { invalid: true };
     }
+
+    return null;
+  }
+
+  // If the UI must tell the user that the changes made in the settings have not been saved.
+  get settingsChanged(): boolean {
+    return this.initialKillswitchSetting !== this.settingsForm.get('killswitch').value ||
+      this.initialDnsSetting !== this.settingsForm.get('dns').value ;
   }
 
   // Opens the modal window for selecting the filters.
@@ -499,7 +522,10 @@ export class SkysocksClientSettingsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const data = { killswitch: this.killswitch };
+    const data = {
+      killswitch: this.settingsForm.get('killswitch').value,
+      dns: this.settingsForm.get('dns').value,
+    };
 
     this.settingsButton.showLoading(false);
     this.button.showLoading(false);
@@ -511,7 +537,8 @@ export class SkysocksClientSettingsComponent implements OnInit, OnDestroy {
       data,
     ).subscribe(
       () => {
-        this.initialKillswitchSetting = this.killswitch;
+        this.initialKillswitchSetting = data.killswitch;
+        this.initialDnsSetting = data.dns;
 
         this.snackbarService.showDone('apps.vpn-socks-client-settings.changes-made');
 

--- a/static/skywire-manager-src/src/app/components/vpn/layout/vpn-dns-config/vpn-dns-config.component.ts
+++ b/static/skywire-manager-src/src/app/components/vpn/layout/vpn-dns-config/vpn-dns-config.component.ts
@@ -10,6 +10,7 @@ import { OperationError } from 'src/app/utils/operation-error';
 import { processServiceError } from 'src/app/utils/errors';
 import { AppsService } from 'src/app/services/apps.service';
 import { VpnClientService } from 'src/app/services/vpn-client.service';
+import GeneralUtils from 'src/app/utils/generalUtils';
 
 /**
  * Params for VpnDnsConfigComponent.
@@ -83,21 +84,9 @@ export class VpnDnsConfigComponent implements OnInit, OnDestroy {
   private validateIp() {
     if (this.form) {
       const value = this.form.get('ip').value as string;
-      if (!value) {
-        return;
-      }
+      const validOrEmpty = GeneralUtils.checkIfIpValidOrEmpty(value);
 
-      const parts = value.split('.');
-      if (parts.length !== 4) {
-        return { invalid: true };
-      }
-
-      for (const part of parts) {
-        const number = Number.parseInt(part, 10);
-        if (isNaN(number) || (number + '') !== part || number < 0 || number > 255) {
-          return { invalid: true };
-        }
-      }
+      return validOrEmpty ? null : { invalid: true };
     }
 
     return null;

--- a/static/skywire-manager-src/src/app/utils/generalUtils.ts
+++ b/static/skywire-manager-src/src/app/utils/generalUtils.ts
@@ -63,4 +63,27 @@ export default class GeneralUtils {
 
     return true;
   }
+
+  /**
+   * Validates an IPv4 address.
+   */
+  static checkIfIpValidOrEmpty(value: string): boolean {
+    if (!value) {
+      return true;
+    }
+
+    const parts = value.split('.');
+    if (parts.length !== 4) {
+      return false;
+    }
+
+    for (const part of parts) {
+      const number = Number.parseInt(part, 10);
+      if (isNaN(number) || (number + '') !== part || number < 0 || number > 255) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 }

--- a/static/skywire-manager-src/src/assets/i18n/en.json
+++ b/static/skywire-manager-src/src/assets/i18n/en.json
@@ -431,6 +431,8 @@
       "no-history": "This tab will show the last {{ number }} public keys used.",
       "default-note-warning": "The default note has been used.",
       "pagination-info": "{{ currentElementsRange }} of {{ totalElements }}",
+      "dns": "Custom DNS server IP address",
+      "dns-error": "Invalid value.",
       "killswitch-check": "Activate killswitch",
       "killswitch-info": "When active, all network connections will be disabled if the app is running but the VPN protection is interrupted (for temporary errors or any other problem). This avoids data leaks.",
       "settings-changed-alert": " The changes have not been saved yet.",

--- a/static/skywire-manager-src/src/assets/i18n/es.json
+++ b/static/skywire-manager-src/src/assets/i18n/es.json
@@ -435,6 +435,8 @@
       "no-history": "Esta pestaña mostrará las últimas {{ number }} llaves públicas usadas.",
       "default-note-warning": "La nota por defecto ha sido utilizada.",
       "pagination-info": "{{ currentElementsRange }} de {{ totalElements }}",
+      "dns": "Dirección IP del servidor DNS personalizado",
+      "dns-error": "Valor inválido.",
       "killswitch-check": "Activar killswitch",
       "killswitch-info": "Cuando está activo, todas las conexiones de red se desactivarán si la aplicación se está ejecutando pero la protección VPN está interrumpida (por errores temporales o cualquier otro problema). Esto evita fugas de datos.",
       "settings-changed-alert": "Los cambios aún no se han guardado.",

--- a/static/skywire-manager-src/src/assets/i18n/es_base.json
+++ b/static/skywire-manager-src/src/assets/i18n/es_base.json
@@ -435,6 +435,8 @@
       "no-history": "This tab will show the last {{ number }} public keys used.",
       "default-note-warning": "The default note has been used.",
       "pagination-info": "{{ currentElementsRange }} of {{ totalElements }}",
+      "dns": "Custom DNS server IP address",
+      "dns-error": "Invalid value.",
       "killswitch-check": "Activate killswitch",
       "killswitch-info": "When active, all network connections will be disabled if the app is running but the VPN protection is interrupted (for temporary errors or any other problem). This avoids data leaks.",
       "settings-changed-alert": " The changes have not been saved yet.",


### PR DESCRIPTION
Did you run `make format && make check`?
The go code was not changed. `npm run lint` and `npm run build` were used.

 Changes:	
- Now the modal window for configuring the vpn-client app from the Skywire Manager allows to set a custom DNS server.
![pw](https://user-images.githubusercontent.com/34079003/178359012-14cb199a-21ab-485b-aad2-06695b7fdbf5.png)
- The settings tab was removed from the modal window for configuring the skysocks-client app.

How to test this PR:
Check the modal window.
